### PR TITLE
Remove missing symbols from export lists.

### DIFF
--- a/modules/dbus/connection.scm
+++ b/modules/dbus/connection.scm
@@ -1,7 +1,5 @@
 (define-module (dbus connection)
-  #:export (;dbus-connection
-            make-dbus-connection
-            ; dbus-connection?
+  #:export (make-dbus-connection
             dbus-connection-send
             dbus-connection-send/with-reply
             dbus-connection-send/with-reply-and-block

--- a/modules/dbus/connection.scm
+++ b/modules/dbus/connection.scm
@@ -1,7 +1,7 @@
 (define-module (dbus connection)
-  #:export (dbus-connection
+  #:export (;dbus-connection
             make-dbus-connection
-            dbus-connection?
+            ; dbus-connection?
             dbus-connection-send
             dbus-connection-send/with-reply
             dbus-connection-send/with-reply-and-block

--- a/modules/dbus/message.scm
+++ b/modules/dbus/message.scm
@@ -1,6 +1,5 @@
 (define-module (dbus message)
-  #:export (; dbus-message
-            dbus-message?
+  #:export (dbus-message?
             make-dbus-message
             make-dbus-message/method-call
             make-dbus-message/method-return

--- a/modules/dbus/message.scm
+++ b/modules/dbus/message.scm
@@ -1,5 +1,5 @@
 (define-module (dbus message)
-  #:export (dbus-message
+  #:export (; dbus-message
             dbus-message?
             make-dbus-message
             make-dbus-message/method-call

--- a/modules/dbus/pending-call.scm
+++ b/modules/dbus/pending-call.scm
@@ -1,6 +1,5 @@
 (define-module (dbus pending-call)
-  #:export (;dbus-pending-call
-            dbus-pending-call-block
+  #:export (dbus-pending-call-block
             dbus-pending-call-cancel
             dbus-pending-call-steal-reply
             dbus-pending-call-completed?))

--- a/modules/dbus/pending-call.scm
+++ b/modules/dbus/pending-call.scm
@@ -1,5 +1,5 @@
 (define-module (dbus pending-call)
-  #:export (dbus-pending-call
+  #:export (;dbus-pending-call
             dbus-pending-call-block
             dbus-pending-call-cancel
             dbus-pending-call-steal-reply


### PR DESCRIPTION
I would guess that most of these were the symbol for the data-type. But since that doesn't exist, and we couldn't even do anything with it if it existed, I have removed it.

This also removes `dbus-connection?`, since it wasn't implemented. It would however be a good idea to implement it.

I separated the merge request into two commits, where the earlier one just comments out the unused symbols.