### PR TITLE
Add support for remaining simple types.

### DIFF
--- a/libguile-dbus/dbus-message-func.c
+++ b/libguile-dbus/dbus-message-func.c
@@ -302,11 +302,13 @@ GDBUS_DEFINE(gdbus_message_get_args, "%dbus-message-get-args", 2,
 
     if (scm_is_false(types)) {
         if (! dbus_message_iter_init(data->message, &iter)) {
+             /* Message had no arguments, return our empty list */
             return result;
         }
 
-        for (; dbus_message_iter_has_next(&iter); dbus_message_iter_next(&iter)) {
-            int c_type = dbus_message_iter_get_arg_type(&iter);
+        int c_type;
+        while ((c_type = dbus_message_iter_get_arg_type(&iter))
+               != DBUS_TYPE_INVALID) {
             SCM type = dbus_type_to_scm(c_type);
             DBusBasicValue c_value;
 
@@ -314,6 +316,8 @@ GDBUS_DEFINE(gdbus_message_get_args, "%dbus-message-get-args", 2,
 
             SCM value = dbus_value_to_scm(c_type, c_value);
             result = scm_append(scm_list_2(result, scm_list_2(type, value)));
+
+            dbus_message_iter_next(&iter);
         }
     } else {
         if (! dbus_message_iter_init(data->message, &iter)) {

--- a/libguile-dbus/dbus-message-func.c
+++ b/libguile-dbus/dbus-message-func.c
@@ -150,6 +150,7 @@ GDBUS_DEFINE(gdbus_messsage_new_signal, "%make-dbus-message/signal", 3,
 }
 #undef FUNC_NAME
 
+/* See https://dbus.freedesktop.org/doc/api/html/group__DBusProtocol.html */
 GDBUS_DEFINE(gdbus_message_append_args, "%dbus-message-append-args", 2,
              (SCM message, SCM args),
              "Append arguments ARGS to the MESSAGE.")
@@ -178,13 +179,19 @@ GDBUS_DEFINE(gdbus_message_append_args, "%dbus-message-append-args", 2,
                 gdbus_error(FUNC_NAME, "Unknown type", scm_type);
             }
             switch (symbol->value) {
+            case DBUS_TYPE_BOOLEAN: {
+                /* This makes any non-false value true */
+                dbus_bool_t value = scm_is_true(scm_value);
+                dbus_message_iter_append_basic(&iter, symbol->value, &value);
+                break;
+            }
             case DBUS_TYPE_BYTE: {
-                unsigned char value = scm_to_uchar(scm_value);
+                unsigned char value = scm_to_uint8(scm_value);
                 dbus_message_iter_append_basic(&iter, symbol->value, &value);
                 break;
             }
             case DBUS_TYPE_INT16: {
-                dbus_int16_t value = scm_to_short(scm_value);
+                dbus_int16_t value = scm_to_int16(scm_value);
                 dbus_message_iter_append_basic(&iter, symbol->value, &value);
                 break;
             }
@@ -208,8 +215,33 @@ GDBUS_DEFINE(gdbus_message_append_args, "%dbus-message-append-args", 2,
                 dbus_message_iter_append_basic(&iter, symbol->value, &value);
                 break;
             }
+            case DBUS_TYPE_UINT64: {
+                 dbus_uint64_t value = scm_to_uint64(scm_value);
+                 dbus_message_iter_append_basic(&iter, symbol->value, &value);
+                 break;
+            }
+            /* Object paths and signatures technically have to be validated,
+               but are otherwise identical to strings. See
+               https://dbus.freedesktop.org/doc/dbus-specification.html#type-system */
+            case DBUS_TYPE_OBJECT_PATH:
+            case DBUS_TYPE_SIGNATURE:
             case DBUS_TYPE_STRING: {
-                char* value = scm_to_locale_string(scm_value);
+                char* value = scm_to_utf8_stringn(scm_value, NULL);
+                dbus_message_iter_append_basic(&iter, symbol->value, &value);
+                break;
+            }
+            case DBUS_TYPE_DOUBLE: {
+                /* While techincly not exactly correct, since DBUS_TYPE_DOUBLE
+                   marks an 8-byte IEEE754 double, while C doesn't have that
+                   guarantee, it will still be right in 99%+ of cases */
+                double value = scm_to_double(scm_value);
+                dbus_message_iter_append_basic(&iter, symbol->value, &value);
+                break;
+            }
+            case DBUS_TYPE_UNIX_FD: {
+                /* Explicitly the system dependant int types, since
+                   file descriptors are system dependant */
+                int value = scm_to_uint(scm_fileno(scm_value));
                 dbus_message_iter_append_basic(&iter, symbol->value, &value);
                 break;
             }
@@ -241,8 +273,7 @@ GDBUS_DEFINE(gdbus_message_append_args, "%dbus-message-append-args", 2,
                 break;
             }
 
-            case DBUS_TYPE_UINT64:
-            case DBUS_TYPE_DOUBLE:
+            default:
                 gdbus_error(FUNC_NAME, "Unsupported yet",
                             scm_list_2(message, args));
             }

--- a/libguile-dbus/symbols.c
+++ b/libguile-dbus/symbols.c
@@ -73,11 +73,11 @@ SCM dbus_value_to_scm(int type, DBusBasicValue value)
     case DBUS_TYPE_INT16:
         return scm_from_short(value.i16);
 
-    case DBUS_TYPE_INT32:
-        return scm_from_int32(value.i32);
-
     case DBUS_TYPE_UINT16:
         return scm_from_uint16(value.u16);
+
+    case DBUS_TYPE_INT32:
+        return scm_from_int32(value.i32);
 
     case DBUS_TYPE_UINT32:
         return scm_from_uint32(value.u32);
@@ -91,8 +91,20 @@ SCM dbus_value_to_scm(int type, DBusBasicValue value)
     case DBUS_TYPE_DOUBLE:
         return scm_from_double(value.dbl);
 
+    case DBUS_TYPE_OBJECT_PATH:
+    case DBUS_TYPE_SIGNATURE:
     case DBUS_TYPE_STRING:
         return scm_from_locale_string(value.str);
+
+    case DBUS_TYPE_BOOLEAN:
+         switch (value.bool_val) {
+         case TRUE:  return SCM_BOOL_T;
+         case FALSE: return SCM_BOOL_F;
+         default:    return SCM_BOOL_F; /* possibly throw errer here instead */
+         }
+
+    case DBUS_TYPE_UNIX_FD:
+         return scm_from_int(value.fd);
 
     default:
         return SCM_BOOL_F;      /* The type is unsupported yet. */


### PR DESCRIPTION
As written, this merge request adds support for remaining simple DBus data-types, but only in some contexts. The problem with going all the way is due to Guile DBus not having a clear type definition for complex types, which I have started the discussion about over at https://github.com/artyom-poptsov/guile-dbus/issues/4.